### PR TITLE
Add Support for Root Domain

### DIFF
--- a/certbot_route53/authenticator.py
+++ b/certbot_route53/authenticator.py
@@ -46,7 +46,7 @@ class Authenticator(common.Plugin):
         return max(
             (
                 zone for zone in r53.list_hosted_zones()["HostedZones"]
-                if (domain+".").endswith("."+zone["Name"])
+                if (domain+".").endswith("."+zone["Name"]) or (domain+".") == (zone["Name"])
             ),
             key=lambda zone: len(zone["Name"]),
         )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from distutils.core import setup
 from setuptools import find_packages
 
-version = '0.1.4'
+version = '0.1.5'
 
 install_requires = [
     'acme>=0.9.0.dev0',


### PR DESCRIPTION
This PR enables support for root domains.

## Error
When trying to authenticate a root domain (no subdomains) the following error is produced:

`Unable to find matching Route53 zone for domain example.com`

## Reproduce
```
certbot certonly \
	-n --agree-tos --renew-by-default --text \
	-a certbot-route53:auth \
	-d example.com
```