### PR TITLE
Make certbot-route53 python3 compatible

### DIFF
--- a/certbot_route53/authenticator.py
+++ b/certbot_route53/authenticator.py
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
 
 TTL = 30
 
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(common.Plugin):
-    zope.interface.implements(interfaces.IAuthenticator)
-    zope.interface.classProvides(interfaces.IPluginFactory)
 
     description = "Route53 Authenticator"
 

--- a/certbot_route53/authenticator.py
+++ b/certbot_route53/authenticator.py
@@ -66,7 +66,7 @@ class Authenticator(common.Plugin):
         response, validation = achall.response_and_validation()
         self._excute_r53_action(r53, achall, zone, validation, 'UPSERT', wait_for_change=True)
 
-        for _ in xrange(TTL*2):
+        for _ in range(TTL*2):
             if response.simple_verify(
                 achall.chall,
                 achall.domain,


### PR DESCRIPTION
This lets certbot-route53 run on python 3.4. I haven't tested it with any other 3.x version of Python, but it should work, in theory.